### PR TITLE
Support to run in the current repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,9 @@ type bumper struct {
 }
 
 func (b *bumper) bump() error {
-	b.listReleases()
+	if err := b.listReleases(); err != nil {
+		return err
+	}
 	current, err := b.currentVersion()
 	if err != nil {
 		return err


### PR DESCRIPTION
fix #1 

gh bump uses `-R` option to exec gh commands.
It doesn't work in github enterprise repository because gh commands use github.com as hostname by default where the current repository is not the context.

I fixed to run without -R option when -R option of gh bump wasn't given.