### PR TITLE
remove is initial field from bumper

### DIFF
--- a/bump/bumper.go
+++ b/bump/bumper.go
@@ -19,10 +19,9 @@ type Gh interface {
 }
 
 type bumper struct {
-	gh               Gh
-	repository       string
-	isCurrent        bool
-	isInitialVersion bool
+	gh         Gh
+	repository string
+	isCurrent  bool
 }
 
 func New(gh Gh) cmd.Bumper {
@@ -36,13 +35,18 @@ func (b *bumper) Bump() error {
 	}
 	fmt.Println(releases)
 
-	current, err := b.currentVersion()
+	current, isInitial, err := b.currentVersion()
 	if err != nil {
 		return err
 	}
-	nextVer, err := b.nextVersion(current)
-	if err != nil {
-		return err
+	var nextVer *semver.Version
+	if isInitial {
+		nextVer = current
+	} else {
+		nextVer, err = b.nextVersion(current)
+		if err != nil {
+			return err
+		}
 	}
 
 	ok, err := b.approve(nextVer)
@@ -96,26 +100,27 @@ func (b *bumper) listReleases() (string, error) {
 	return fmt.Sprintf("Tags:\n%s", sout.String()), nil
 }
 
-func (b *bumper) currentVersion() (*semver.Version, error) {
+func (b *bumper) currentVersion() (*semver.Version, bool, error) {
+	var isInitial bool
 	sout, eout, err := b.gh.ViewRelease(b.repository, b.isCurrent)
 	if err != nil {
 		if strings.Contains(eout.String(), "HTTP 404: Not Found") {
 			current, err := newVersion()
 			if err != nil {
-				return nil, err
+				return nil, isInitial, err
 			}
-			b.isInitialVersion = true
-			return current, nil
+			isInitial = true
+			return current, isInitial, nil
 		}
-		return nil, err
+		return nil, isInitial, err
 	}
 	viewOut := strings.Split(sout.String(), "\n")[1]
 	tag := strings.TrimSpace(strings.Split(viewOut, ":")[1])
 	current, err := semver.NewVersion(tag)
 	if err != nil {
-		return nil, fmt.Errorf("invalid version. err: %w", err)
+		return nil, isInitial, fmt.Errorf("invalid version. err: %w", err)
 	}
-	return current, nil
+	return current, isInitial, nil
 }
 
 func newVersion() (*semver.Version, error) {
@@ -139,9 +144,6 @@ func newVersion() (*semver.Version, error) {
 }
 
 func (b *bumper) nextVersion(current *semver.Version) (*semver.Version, error) {
-	if b.isInitialVersion {
-		return current, nil
-	}
 	prompt := promptui.Select{
 		Label: fmt.Sprintf("Select next version. current: %s", current.Original()),
 		Items: []string{"patch", "minor", "major"},


### PR DESCRIPTION
bumper has the isInitialVersion field.
But, bumper should not have this field because this is a field to change process of bumping logic.

I fixed `currentVersion()` method to return isInitial boolean and moved checking isInitial process from `nextVersion()` to `Bump()`.