### PR TITLE
Add support for `--generate-notes` option for `gh release create`

### DIFF
--- a/bump/bumper.go
+++ b/bump/bumper.go
@@ -22,6 +22,7 @@ type ReleaseOption struct {
 	IsDraft            bool
 	IsPrerelease       bool
 	DiscussionCategory string
+	GenerateNotes      bool
 	Notes              string
 	NotesFilename      string
 	Target             string
@@ -35,6 +36,7 @@ type bumper struct {
 	isDraft            bool
 	isPrerelease       bool
 	discussionCategory string
+	generateNotes      bool
 	notes              string
 	notesFilename      string
 	target             string
@@ -70,6 +72,10 @@ func (b *bumper) WithPrerelease() {
 
 func (b *bumper) WithDiscussionCategory(category string) {
 	b.discussionCategory = category
+}
+
+func (b *bumper) WithGenerateNotes() {
+	b.generateNotes = true
 }
 
 func (b *bumper) WithNotes(notes string) {
@@ -238,6 +244,7 @@ func (b *bumper) createRelease(version string) (string, error) {
 		IsDraft:            b.isDraft,
 		IsPrerelease:       b.isPrerelease,
 		DiscussionCategory: b.discussionCategory,
+		GenerateNotes:      b.generateNotes,
 		Notes:              b.notes,
 		NotesFilename:      b.notesFilename,
 		Target:             b.target,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ type Bumper interface {
 	WithDraft()
 	WithPrerelease()
 	WithDiscussionCategory(category string)
+	WithGenerateNotes()
 	WithNotes(notes string)
 	WithNotesFile(filename string)
 	WithTitle(title string)
@@ -22,6 +23,7 @@ func New(bumper Bumper) *cobra.Command {
 		isDraft            bool
 		isPrerelease       bool
 		discussionCategory string
+		generateNotes      bool
 		notes              string
 		notesFile          string
 		target             string
@@ -43,6 +45,9 @@ func New(bumper Bumper) *cobra.Command {
 			if discussionCategory != "" {
 				bumper.WithDiscussionCategory(discussionCategory)
 			}
+			if generateNotes {
+				bumper.WithGenerateNotes()
+			}
 			if notes != "" {
 				bumper.WithNotes(notes)
 			}
@@ -63,6 +68,7 @@ func New(bumper Bumper) *cobra.Command {
 	cmd.Flags().BoolVarP(&isDraft, "draft", "d", false, "Save the release as a draft instead of publishing it")
 	cmd.Flags().BoolVarP(&isPrerelease, "prerelease", "p", false, "Mark the release as a prerelease")
 	cmd.Flags().StringVarP(&discussionCategory, "discussion-category", "", "", "Start a discussion of the specified category")
+	cmd.Flags().BoolVarP(&generateNotes, "generate-notes", "g", false, "Automatically generate title and notes for the release")
 	cmd.Flags().StringVarP(&notes, "notes", "n", "", "Release notes")
 	cmd.Flags().StringVarP(&notesFile, "notes-file", "F", "", "Read release notes from file")
 	cmd.Flags().StringVarP(&target, "target", "", "", "Target branch or full commit SHA (default: main branch)")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -12,6 +12,7 @@ type mockBumper struct {
 	isDraft            bool
 	isPrerelease       bool
 	discussionCategory string
+	generateNotes      bool
 	notes              string
 	notesFilename      string
 	target             string
@@ -39,6 +40,10 @@ func (b *mockBumper) WithDiscussionCategory(category string) {
 	b.discussionCategory = category
 }
 
+func (b *mockBumper) WithGenerateNotes() {
+	b.generateNotes = true
+}
+
 func (b *mockBumper) WithNotes(notes string) {
 	b.notes = notes
 }
@@ -62,6 +67,7 @@ func TestNew(t *testing.T) {
 		wantDraft              bool
 		wantPrerelease         bool
 		wantDiscussionCategory string
+		generateNotes          bool
 		wantNotes              string
 		wantNotesFilename      string
 		wantTarget             string
@@ -86,6 +92,10 @@ func TestNew(t *testing.T) {
 		"with discussion category": {
 			command:                "bump --discussion-category category!",
 			wantDiscussionCategory: "category!",
+		},
+		"with generate-notes": {
+			command:       "bump --generate-notes",
+			generateNotes: true,
 		},
 		"with notes": {
 			command:   "bump --notes release",

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -52,6 +52,9 @@ func (g *gh) CreateRelease(version string, repo string, isCurrent bool, option *
 	if option.DiscussionCategory != "" {
 		args = append(args, []string{"--discussion-category", option.DiscussionCategory}...)
 	}
+	if option.GenerateNotes {
+		args = append(args, "--generate-notes")
+	}
 	if option.Notes != "" {
 		args = append(args, []string{"--notes", option.Notes}...)
 	}


### PR DESCRIPTION
The PR adds `--generate-notes` option for `gh release create`.

`
--generate-notes               Automatically generate title and notes for the release
`