### PR TITLE
Feature/bump type option

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+        informational: true
+    patch: off

--- a/bump/bumper.go
+++ b/bump/bumper.go
@@ -41,6 +41,7 @@ type bumper struct {
 	notesFilename      string
 	target             string
 	title              string
+	bumpType           BumpType
 }
 
 func New(gh Gh) *bumper {
@@ -94,6 +95,15 @@ func (b *bumper) WithTitle(title string) {
 	b.title = title
 }
 
+func (b *bumper) WithBumpType(s string) error {
+	bumpType, err := ParseBumpType(s)
+	if err != nil {
+		return err
+	}
+	b.bumpType = bumpType
+	return nil
+}
+
 func (b *bumper) Bump() error {
 	releases, err := b.listReleases()
 	if err != nil {
@@ -106,7 +116,12 @@ func (b *bumper) Bump() error {
 		return err
 	}
 	var nextVer *semver.Version
-	if isInitial {
+	if b.bumpType.Valid() == nil && !b.bumpType.IsBlank() {
+		nextVer, err = incrementVersion(current, b.bumpType.String())
+		if err != nil {
+			return err
+		}
+	} else if isInitial {
 		nextVer = current
 	} else {
 		nextVer, err = nextVersion(current, os.Stdin, os.Stdout)

--- a/bump/bumper.go
+++ b/bump/bumper.go
@@ -121,13 +121,13 @@ func (b *bumper) Bump() error {
 		return err
 	}
 	var nextVer *semver.Version
-	if b.bumpType.Valid() == nil && !b.bumpType.IsBlank() {
+	if isInitial {
+		nextVer = current
+	} else if b.bumpType.Valid() == nil && !b.bumpType.IsBlank() {
 		nextVer, err = incrementVersion(current, b.bumpType.String())
 		if err != nil {
 			return err
 		}
-	} else if isInitial {
-		nextVer = current
 	} else {
 		nextVer, err = nextVersion(current, os.Stdin, os.Stdout)
 		if err != nil {

--- a/bump/bumper.go
+++ b/bump/bumper.go
@@ -42,6 +42,7 @@ type bumper struct {
 	target             string
 	title              string
 	bumpType           BumpType
+	yes                bool
 }
 
 func New(gh Gh) *bumper {
@@ -104,6 +105,10 @@ func (b *bumper) WithBumpType(s string) error {
 	return nil
 }
 
+func (b *bumper) WithYes() {
+	b.yes = true
+}
+
 func (b *bumper) Bump() error {
 	releases, err := b.listReleases()
 	if err != nil {
@@ -130,13 +135,16 @@ func (b *bumper) Bump() error {
 		}
 	}
 
-	ok, err := approve(nextVer, os.Stdin, os.Stdout)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		fmt.Println("Bump was canceled.")
-		return nil
+	// Skip approval if --yes is set
+	if !b.yes {
+		ok, err := approve(nextVer, os.Stdin, os.Stdout)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Println("Bump was canceled.")
+			return nil
+		}
 	}
 
 	result, err := b.createRelease(nextVer.Original())

--- a/bump/bumper_test.go
+++ b/bump/bumper_test.go
@@ -180,6 +180,16 @@ func TestBumper_WithBumpType(t *testing.T) {
 	}
 }
 
+func TestBumper_WithYes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gh := mock_bump.NewMockGh(ctrl)
+	b := bump.New(gh)
+	b.WithYes()
+	assert.True(t, b.Yes())
+}
+
 func TestBumper_ResolveRepository(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bump/bumper_test.go
+++ b/bump/bumper_test.go
@@ -148,6 +148,38 @@ func TestBumper_WithTitle(t *testing.T) {
 	assert.Equal(t, "title", b.Title())
 }
 
+func TestBumper_WithBumpType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gh := mock_bump.NewMockGh(ctrl)
+	tests := map[string]struct {
+		s       string
+		want    bump.BumpType
+		wantErr error
+	}{
+		"major": {
+			s:       "major",
+			want:    bump.Major,
+			wantErr: nil,
+		},
+		"invalid": {
+			s:       "invalid",
+			want:    "",
+			wantErr: fmt.Errorf("%w: got invalid", bump.ErrInvalidBumpType),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := bump.New(gh)
+			err := b.WithBumpType(tt.s)
+			assert.Equal(t, tt.want, b.BumpType())
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
 func TestBumper_ResolveRepository(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bump/enum.go
+++ b/bump/enum.go
@@ -1,0 +1,42 @@
+package bump
+
+import (
+	"errors"
+	"fmt"
+)
+
+type BumpType string
+
+const (
+	Major BumpType = "major"
+	Minor BumpType = "minor"
+	Patch BumpType = "patch"
+	Blank BumpType = ""
+)
+
+var ErrInvalidBumpType = errors.New("invalid bump type")
+
+func (b BumpType) String() string {
+	return string(b)
+}
+
+func (b BumpType) IsBlank() bool {
+	return b == Blank
+}
+
+func (b BumpType) Valid() error {
+	switch b {
+	case Major, Minor, Patch:
+		return nil
+	default:
+		return fmt.Errorf("%w: got %s", ErrInvalidBumpType, b)
+	}
+}
+
+func ParseBumpType(s string) (BumpType, error) {
+	b := BumpType(s)
+	if err := b.Valid(); err != nil {
+		return "", err
+	}
+	return b, nil
+}

--- a/bump/enum_test.go
+++ b/bump/enum_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/johnmanjiro13/gh-bump/bump"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/johnmanjiro13/gh-bump/bump"
 )
 
 func TestBumpType_String(t *testing.T) {

--- a/bump/enum_test.go
+++ b/bump/enum_test.go
@@ -1,0 +1,94 @@
+package bump_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/johnmanjiro13/gh-bump/bump"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBumpType_String(t *testing.T) {
+	bumpType := bump.BumpType("major")
+	assert.Equal(t, "major", bumpType.String())
+}
+
+func TestBumpType_IsBlank(t *testing.T) {
+	tests := map[string]struct {
+		bumpType bump.BumpType
+		want     bool
+	}{
+		"major": {
+			bumpType: bump.Major,
+			want:     false,
+		},
+		"blank": {
+			bumpType: bump.Blank,
+			want:     true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.bumpType.IsBlank())
+		})
+	}
+}
+
+func TestBumpType_Valid(t *testing.T) {
+	tests := map[string]struct {
+		bumpType string
+		want     error
+	}{
+		"major": {
+			bumpType: "major",
+			want:     nil,
+		},
+		"minor": {
+			bumpType: "minor",
+			want:     nil,
+		},
+		"patch": {
+			bumpType: "patch",
+			want:     nil,
+		},
+		"invalid": {
+			bumpType: "invalid",
+			want:     fmt.Errorf("%w: got invalid", bump.ErrInvalidBumpType),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			bumpType := bump.BumpType(tt.bumpType)
+			assert.Equal(t, tt.want, bumpType.Valid())
+		})
+	}
+}
+
+func TestParseBumpType(t *testing.T) {
+	tests := map[string]struct {
+		s       string
+		want    bump.BumpType
+		wantErr error
+	}{
+		"major": {
+			s:       "major",
+			want:    bump.BumpType("major"),
+			wantErr: nil,
+		},
+		"invalid": {
+			s:       "invalid",
+			want:    "",
+			wantErr: fmt.Errorf("%w: got invalid", bump.ErrInvalidBumpType),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := bump.ParseBumpType(tt.s)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}

--- a/bump/export_test.go
+++ b/bump/export_test.go
@@ -54,3 +54,7 @@ func (b *bumper) Title() string {
 func (b *bumper) BumpType() BumpType {
 	return b.bumpType
 }
+
+func (b *bumper) Yes() bool {
+	return b.yes
+}

--- a/bump/export_test.go
+++ b/bump/export_test.go
@@ -50,3 +50,7 @@ func (b *bumper) Target() string {
 func (b *bumper) Title() string {
 	return b.title
 }
+
+func (b *bumper) BumpType() BumpType {
+	return b.bumpType
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ type Bumper interface {
 	WithTitle(title string)
 	WithTarget(target string)
 	WithBumpType(bumpType string) error
+	WithYes()
 }
 
 func New(bumper Bumper) *cobra.Command {
@@ -30,6 +31,7 @@ func New(bumper Bumper) *cobra.Command {
 		target             string
 		title              string
 		bumpType           string
+		yes                bool
 	)
 	cmd := &cobra.Command{
 		Use:   "bump",
@@ -68,6 +70,9 @@ func New(bumper Bumper) *cobra.Command {
 					return err
 				}
 			}
+			if yes {
+				bumper.WithYes()
+			}
 			return bumper.Bump()
 		},
 	}
@@ -82,5 +87,6 @@ func New(bumper Bumper) *cobra.Command {
 	cmd.Flags().StringVarP(&target, "target", "", "", "Target branch or full commit SHA (default: main branch)")
 	cmd.Flags().StringVarP(&title, "title", "t", "", "Release title")
 	cmd.Flags().StringVarP(&bumpType, "bump-type", "", "", "Bump type (major, minor or patch)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Answer 'yes' to all questions")
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ type Bumper interface {
 	WithNotesFile(filename string)
 	WithTitle(title string)
 	WithTarget(target string)
+	WithBumpType(bumpType string) error
 }
 
 func New(bumper Bumper) *cobra.Command {
@@ -28,6 +29,7 @@ func New(bumper Bumper) *cobra.Command {
 		notesFile          string
 		target             string
 		title              string
+		bumpType           string
 	)
 	cmd := &cobra.Command{
 		Use:   "bump",
@@ -60,6 +62,12 @@ func New(bumper Bumper) *cobra.Command {
 			if title != "" {
 				bumper.WithTitle(title)
 			}
+			if bumpType != "" {
+				err := bumper.WithBumpType(bumpType)
+				if err != nil {
+					return err
+				}
+			}
 			return bumper.Bump()
 		},
 	}
@@ -73,5 +81,6 @@ func New(bumper Bumper) *cobra.Command {
 	cmd.Flags().StringVarP(&notesFile, "notes-file", "F", "", "Read release notes from file")
 	cmd.Flags().StringVarP(&target, "target", "", "", "Target branch or full commit SHA (default: main branch)")
 	cmd.Flags().StringVarP(&title, "title", "t", "", "Release title")
+	cmd.Flags().StringVarP(&bumpType, "bump-type", "", "", "Bump type (major, minor or patch)")
 	return cmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/johnmanjiro13/gh-bump/bump"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,6 +18,8 @@ type mockBumper struct {
 	notesFilename      string
 	target             string
 	title              string
+	bumpType           bump.BumpType
+	yes                bool
 }
 
 func (b *mockBumper) Bump() error {
@@ -60,6 +63,19 @@ func (b *mockBumper) WithTarget(target string) {
 	b.target = target
 }
 
+func (b *mockBumper) WithBumpType(s string) error {
+	bumpType, err := bump.ParseBumpType(s)
+	if err != nil {
+		return err
+	}
+	b.bumpType = bumpType
+	return nil
+}
+
+func (b *mockBumper) WithYes() {
+	b.yes = true
+}
+
 func TestNew(t *testing.T) {
 	tests := map[string]struct {
 		command                string
@@ -72,6 +88,8 @@ func TestNew(t *testing.T) {
 		wantNotesFilename      string
 		wantTarget             string
 		wantTitle              string
+		wantBumpType           bump.BumpType
+		wantYes                bool
 	}{
 		"repository given": {
 			command:  "bump -R johnmanjiro13/gh-bump",
@@ -113,6 +131,14 @@ func TestNew(t *testing.T) {
 			command:   "bump -t test_title",
 			wantTitle: "test_title",
 		},
+		"with bump type": {
+			command:      "bump --bump-type major",
+			wantBumpType: bump.Major,
+		},
+		"with yes": {
+			command: "bump --yes",
+			wantYes: true,
+		},
 	}
 
 	for name, tt := range tests {
@@ -131,6 +157,8 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.wantNotesFilename, bumper.notesFilename)
 			assert.Equal(t, tt.wantTarget, bumper.target)
 			assert.Equal(t, tt.wantTitle, bumper.title)
+			assert.Equal(t, tt.wantBumpType, bumper.bumpType)
+			assert.Equal(t, tt.wantYes, bumper.yes)
 		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/johnmanjiro13/gh-bump/bump"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/johnmanjiro13/gh-bump/bump"
 )
 
 type mockBumper struct {


### PR DESCRIPTION
close: #34 

I added `--bump-type` and `--yes` options.
We can use gh bump as one liner like `gh bump -y --bump-type=major`.